### PR TITLE
Missing Language and Database Constant

### DIFF
--- a/zc_plugins/AbuseIPDB/v3.0.0/Installer/ScriptedInstaller.php
+++ b/zc_plugins/AbuseIPDB/v3.0.0/Installer/ScriptedInstaller.php
@@ -101,7 +101,7 @@ class ScriptedInstaller extends ScriptedInstallBase
 
             // Register admin page
             $pageKey = 'configAbuseIPDB';
-            $checkPageSql = "SELECT COUNT(*) AS count FROM admin_pages WHERE page_key = :page_key";
+            $checkPageSql = "SELECT COUNT(*) AS count FROM " . TABLE_ADMIN_PAGES . " WHERE page_key = :page_key";
             $checkPageSql = $db->bindVars($checkPageSql, ':page_key', $pageKey, 'string');
             $result = $db->Execute($checkPageSql);
 

--- a/zc_plugins/AbuseIPDB/v3.0.0/admin/includes/languages/english/extra_definitions/lang.abuseipdb_admin_names.php
+++ b/zc_plugins/AbuseIPDB/v3.0.0/admin/includes/languages/english/extra_definitions/lang.abuseipdb_admin_names.php
@@ -12,4 +12,5 @@
  */
 return [
     'BOX_ABUSEIPDB_NAME' => 'AbuseIPDB Settings',
+    'BOX_ABUSEIPDB_HEADER' => 'AbuseIPDB Contributor'
 ];


### PR DESCRIPTION
Two missing constants are defined.

- BOX_ABUSEIPDB_HEADER breaks the front page as its not defined anywhere. (Added it to the language file)
- The table name "admin_pages" was used instead of TABLE_ADMIN_PAGES. This breaks the installation if it has a prefix assigned to it.